### PR TITLE
feat/nixos diff

### DIFF
--- a/pkgs/apps/nixos-diff/default.nix
+++ b/pkgs/apps/nixos-diff/default.nix
@@ -1,0 +1,85 @@
+{ lib
+, diffutils
+, nix
+, python3
+, stdenvNoCC
+, writeShellApplication
+, writers
+}:
+let
+  script = writers.writePython3 "format-nixpkgs-diff" { } (builtins.readFile ./format-nixpkgs-diff.py);
+in
+writeShellApplication {
+  name = "nixos-diff";
+  text = ''
+    usage() {
+      cat <<EOF # remove the space between << and EOF, this is due to web plugin issue
+    Usage: ''$(
+        basename "''${BASH_SOURCE[0]}"
+      ) <cmd> from-path to-path [-h] [-v]
+
+      Show the diff of two nix store paths
+
+    Available options:
+
+    -h, --help      Print this help and exit
+    -v, --verbose   Print script debug info
+    EOF
+      exit
+    }
+
+    cleanup() {
+      trap - SIGINT SIGTERM ERR EXIT
+      # script cleanup here
+    }
+
+    msg() {
+      echo >&2 -e "''${1-}"
+    }
+
+    die() {
+      local msg=''$1
+      local code=''${2-1} # default exit status 1
+      msg "''$msg"
+      exit "''$code"
+    }
+
+    parse_params() {
+      # default values of variables set from params
+      from_file=0
+      FROMPATH=""
+      TOPATH=""
+      while (( $# > 0 )) do
+        case "''${1-}" in
+        -h | --help) usage ;;
+        -v | --verbose) set -x ;;
+        -f | --from-file) from_file=1;;
+        -- ) break ;;
+        -?*) break ;;
+        *)
+          FROMPATH="''${1-}"
+          TOPATH="''${2-}"
+          shift
+        ;;
+        esac
+        shift
+      done
+      return 0
+    }
+
+    parse_params "''$@"
+
+    if [ "''${from_file}" -eq 0 ]; then
+      FROMTMP=$(mktemp)
+      TOTMP=$(mktemp)
+      ${nix}/bin/nix path-info -r "''${FROMPATH}" | cut -d'-' -f2- | sort | sed -e "s/-[a-z]\+$//g" | uniq > "''${FROMTMP}"
+      ${nix}/bin/nix path-info -r "''${TOPATH}" | cut -d'-' -f2- | sort | sed -e "s/-[a-z]\+$//g" | uniq > "''${TOTMP}"
+      FROMPATH=''${FROMTMP}
+      TOPATH=''${TOTMP}
+    fi
+    ${diffutils}/bin/diff -y --suppress-common-lines "''${FROMPATH}" "''${TOPATH}"  | ${script} | column -t -c 80 -L
+
+    [ -n "''${FROMTMP}" ] && rm "''${FROMTMP}"
+    [ -n "''${TOTMP}" ] && rm "''${TOTMP}"
+  '';
+}

--- a/pkgs/apps/nixos-diff/format-nixpkgs-diff.py
+++ b/pkgs/apps/nixos-diff/format-nixpkgs-diff.py
@@ -1,0 +1,62 @@
+import re
+import sys
+
+pname_version = re.compile(r"^(.+?)(-([0-9].*?))?$")
+pname_hash = re.compile(r"(-([^-]*?))$")
+
+
+def main(diff_txt):
+    updates = [
+        "## Update-packages\n",
+        "| Package | From | To |",
+        "| --- | --- | --- |"
+    ]
+    adds = ["## New-packages\n", "| Package | Version |", "| --- | --- |"]
+    removes = [
+        "## Remove-packages\n",
+        "| Package | Version |",
+        "| --- | --- |"
+    ]
+    for line in diff_txt:
+        line = re.sub(r"\t|\s", "", line)
+        if "|" in line:
+            from_pkg, to_pkg = line.split("|")
+            flag = 0
+        elif "<" in line:
+            from_pkg, to_pkg = line.split("<")
+            flag = 1
+        else:
+            from_pkg, to_pkg = line.split(">")
+            flag = 2
+        result = []
+        for i, pkg in enumerate([from_pkg, to_pkg]):
+            if pkg != "":
+                match = pname_version.search(pkg)
+                if match.group(2) is None:
+                    rematch = pname_hash.search(pkg)
+                    if rematch is not None:
+                        version = rematch.group(1)
+                        pname = re.sub(f"{version}", "", match.group(1))
+                    else:
+                        version, pname = "", ""
+                else:
+                    version = match.group(2)
+                    pname = match.group(1)
+                version = re.sub(r"^-", "", version)
+                result.append((pname, version))
+        if flag == 0 and result[0][1] and result[1][1]:
+            updates.append(
+                f"| {result[0][0]} | {result[0][1]} | {result[1][1]} |"
+            )
+        elif flag == 1 and result[0][1]:
+            removes.append(f"| {result[0][0]} | {result[0][1]} |")
+        elif flag == 2 and result[0][1]:
+            adds.append(f"| {result[0][0]} | {result[0][1]} |")
+    for i in [updates, adds, removes]:
+        if len(i) > 3:
+            print("\n".join(i + [" "]))
+
+
+if __name__ == "__main__":
+    diff_txt = sys.stdin.readlines()
+    main(diff_txt)

--- a/pkgs/packages.toml
+++ b/pkgs/packages.toml
@@ -44,7 +44,7 @@ fetch.url = "https://github.com/dev47apps/droidcam-obs-plugin/releases/download/
 # src.prefix = "x-ken-all-"
 # fetch.url = "https://osdn.net/projects-aur/ponsfoot-aur/storage/mozc/x-ken-all-$ver.zip"
 #
-# [japanese-usege-dictionary]
+# [japanese-usage-dictionary]
 # src.git = "https://github.com/hiroyuki-komatsu/japanese-usage-dictionary"
 # fetch.git = "https://github.com/hiroyuki-komatsu/japanese-usage-dictionary"
 #


### PR DESCRIPTION
- **Update plemoljp-nf: v1.6.0 → v1.7.1 plemoljp: v1.6.0 → v1.7.1 vrchat-vpm-cli: 0.1.22 → 0.1.23 jawiki-kana-kanji-dict: 53f34b277e75d9bae880a4e8cb36acaeb78cb239 → 0e0fb52af809d6f675bf1ba5a828812715957762 plemoljp-hs: v1.6.0 → v1.7.1 vrc-get-latest: v1.5.3 → v1.6.0**
- **Update flake and package version**
- **fix: vrc-getはv1.6.0以降dotnetに依存するためv1.5.*系で一度固定する**
- **Update drbd9-dkms: 9.1.18 → 9.1.19 droidcam-obs-plugin: 2.3.1 → 2.3.2 fcitx5-skk: 5.1.1 → 5.1.2 vrchat-vpm-cli: 0.1.23 → 0.1.24**
- **Update flake and package version**
- **rm: fcitx5-nord  fcitx5-skk is now available on nixpkgs**
- **feat(update-github-actions-permissions): add update-github-actions-permissions**
- **feat(lib.nix): add func of read from generated.json**
- **fix(_sources): remove old version sources**
- **feat(nixos-diff): add nixos-diff script**
- **fix: typos**
