### PR TITLE
feat(mstflint-cx3-support): add mstflint supporting connectx3

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -209,6 +209,21 @@
         },
         "version": "bc4cef188669f88cdeb590fe7afb1021ce2ae481"
     },
+    "mstflint-cx3-support": {
+        "cargoLocks": null,
+        "date": null,
+        "extract": null,
+        "name": "mstflint-cx3-support",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "name": null,
+            "sha256": "sha256-nYGiWfr8a3q3+bGUb1ovLrAS8/LnEJf+4inIEllW95s=",
+            "type": "url",
+            "url": "https://github.com/Mellanox/mstflint/releases/download/v4.25.0-1/mstflint-4.25.0-1.tar.gz"
+        },
+        "version": "4.25.0-1"
+    },
     "openpace": {
         "cargoLocks": null,
         "date": null,

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -115,6 +115,14 @@
     };
     date = "2023-11-01";
   };
+  mstflint-cx3-support = {
+    pname = "mstflint-cx3-support";
+    version = "4.25.0-1";
+    src = fetchurl {
+      url = "https://github.com/Mellanox/mstflint/releases/download/v4.25.0-1/mstflint-4.25.0-1.tar.gz";
+      sha256 = "sha256-nYGiWfr8a3q3+bGUb1ovLrAS8/LnEJf+4inIEllW95s=";
+    };
+  };
   openpace = {
     pname = "openpace";
     version = "1.1.3";

--- a/pkgs/apps/mstflint-cx3-support/default.nix
+++ b/pkgs/apps/mstflint-cx3-support/default.nix
@@ -1,0 +1,48 @@
+{
+  name,
+  pkgSources,
+  lib,
+  stdenv,
+  libibmad,
+  openssl,
+  zlib,
+}:
+
+stdenv.mkDerivation rec {
+  # pname = "mstflint-cx3-support";
+  # version = "4.25.0-1";
+  inherit (pkgSources."${name}") pname version src;
+
+  # src = fetchurl {
+  #   url = "https://github.com/Mellanox/mstflint/releases/download/v${version}/mstflint-${version}.tar.gz";
+  #   sha256 = "sha256-nYGiWfr8a3q3+bGUb1ovLrAS8/LnEJf+4inIEllW95s=";
+  # };
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error=implicit-function-declaration"
+    "-Wno-error=int-conversion"
+  ];
+
+  buildInputs = [
+    libibmad
+    openssl
+    zlib
+  ];
+
+  hardeningDisable = [ "format" ];
+
+  dontDisableStatic = true; # the build fails without this. should probably be reported upstream
+  preConfigure = ''
+    export CPPFLAGS="-I$(pwd)/tools_layouts"
+    export INSTALL_BASEDIR=$out
+  '';
+
+  meta = with lib; {
+    description = "Open source version of Mellanox Firmware Tools (MFT)";
+    homepage = "https://github.com/Mellanox/mstflint";
+    license = with licenses; [
+      gpl2
+      bsd2
+    ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/packages.toml
+++ b/pkgs/packages.toml
@@ -38,6 +38,10 @@ fetch.github = "ClusterLabs/fence-agents"
 src.git = "https://github.com/ku-nlp/knp/"
 fetch.github = "ku-nlp/knp"
 
+[mstflint-cx3-support]
+src.manual = "4.25.0-1"
+fetch.url = "https://github.com/Mellanox/mstflint/releases/download/v$ver/mstflint-$ver.tar.gz"
+
 [proton-ge-rtsp-bin]
 src.github_tag = "SpookySkeletons/proton-ge-rtsp"
 src.include_regex = "GE-Proton.*"


### PR DESCRIPTION
support for connectx-3(-pro) is gone after v4.26.0-1 (Mellanox/mstflint#1157)
